### PR TITLE
Add riscv_int.h and define int_xlen_t and uint_xlen_t

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -238,7 +238,7 @@ vint8m1_t __riscv_vadd_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl); // vadd
 ### riscv_int.h
 
 This header file defined several common RISC-V specific integer type and related
-marco could be used in intrinsic interface or user program directly.
+macro could be used in intrinsic interface or user program directly.
 
 | Type Name             | Meaning                              |
 | --------------------- | ------------------------------------ |
@@ -250,17 +250,17 @@ marco could be used in intrinsic interface or user program directly.
 | __RISCV_INT_XLEN_MAX  | Maximum value of int_xlen_t          |
 | __RISCV_INT_XLEN_MIN  | Minimum value of int_xlen_t          |
 | __RISCV_UINT_XLEN_MAX | Maximum value of uint_xlen_t         |
-| __RISCV_PRIdXLEN      | Expand to a string literal for use as a `d` print specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_PRIiXLEN      | Expand to a string literal for use as a `i` print specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_PRIoXLEN      | Expand to a string literal for use as a `o` print specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_PRIuXLEN      | Expand to a string literal for use as a `u` print specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_PRIxXLEN      | Expand to a string literal for use as a `x` print specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_PRIXXLEN      | Expand to a string literal for use as a `X` print specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_SCNdXLEN      | Expand to a string literal for use as a `d` scan specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_SCNiXLEN      | Expand to a string literal for use as a `i` scan specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_SCNoXLEN      | Expand to a string literal for use as a `o` scan specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_SCNuXLEN      | Expand to a string literal for use as a `u` scan specificier for int_xlen_t/uint_xlen_t. |
-| __RISCV_SCNxXLEN      | Expand to a string literal for use as a `x` scan specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIdXLEN      | Expand to a string literal for use as a `d` print specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIiXLEN      | Expand to a string literal for use as a `i` print specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIoXLEN      | Expand to a string literal for use as a `o` print specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIuXLEN      | Expand to a string literal for use as a `u` print specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIxXLEN      | Expand to a string literal for use as a `x` print specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIXXLEN      | Expand to a string literal for use as a `X` print specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNdXLEN      | Expand to a string literal for use as a `d` scan specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNiXLEN      | Expand to a string literal for use as a `i` scan specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNoXLEN      | Expand to a string literal for use as a `o` scan specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNuXLEN      | Expand to a string literal for use as a `u` scan specifier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNxXLEN      | Expand to a string literal for use as a `x` scan specifier for int_xlen_t/uint_xlen_t. |
 
 
 ## Constraints on Operands of Inline Assembly Statements

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -235,6 +235,27 @@ long __riscv_clmul (long a, long b); // clmul rd, rs1, rs2
 vint8m1_t __riscv_vadd_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl); // vadd.vv vd, vs2, vs1
 ```
 
+### riscv_intrinsic.h
+
+This file is universal intrinsic header file for all extensions, each extension
+could have their own header files, but should included in this file if
+corresponding extension is enabled.
+
+This header file also defined several common RISC-V specific type and related
+marco could be used in intrinsic interface or user program directly.
+
+| Type Name             | Meaning                              |
+| --------------------- | ------------------------------------ |
+| int_xlen_t            | Signed integer type with XLEN bits   |
+| uint_xlen_t           | Unsigned integer type with XLEN bits |
+
+| Macro Name            | Value                                |
+| --------------------- | ------------------------------------ |
+| INT_XLEN_MAX          | Minimum value of int_xlen_t          |
+| INT_XLEN_MIN          | Minimum value of int_xlen_t          |
+| UINT_XLEN_MAX         | Maximum value of uint_xlen_t         |
+| UINT_XLEN_MIN         | Minimum value of uint_xlen_t         |
+
 ## Constraints on Operands of Inline Assembly Statements
 
 This section lists operand constraints that can be used with inline assembly

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -235,26 +235,33 @@ long __riscv_clmul (long a, long b); // clmul rd, rs1, rs2
 vint8m1_t __riscv_vadd_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl); // vadd.vv vd, vs2, vs1
 ```
 
-### riscv_intrinsic.h
+### riscv_int.h
 
-This file is universal intrinsic header file for all extensions, each extension
-could have their own header files, but should included in this file if
-corresponding extension is enabled.
-
-This header file also defined several common RISC-V specific type and related
+This header file defined several common RISC-V specific integer type and related
 marco could be used in intrinsic interface or user program directly.
 
 | Type Name             | Meaning                              |
 | --------------------- | ------------------------------------ |
-| int_xlen_t            | Two's-complement signed integer type with exactly XLEN bits (no padding bits)   |
-| uint_xlen_t           | Unsigned integer type with exactly XLEN bits (no padding bits) |
+| __riscv_int_xlen_t    | Two's-complement signed integer type with exactly XLEN bits (no padding bits)   |
+| __riscv_uint_xlen_t   | Unsigned integer type with exactly XLEN bits (no padding bits) |
 
 | Macro Name            | Value                                |
 | --------------------- | ------------------------------------ |
-| INT_XLEN_MAX          | Maximum value of int_xlen_t          |
-| INT_XLEN_MIN          | Minimum value of int_xlen_t          |
-| UINT_XLEN_MAX         | Maximum value of uint_xlen_t         |
-| UINT_XLEN_MIN         | Minimum value of uint_xlen_t         |
+| __RISCV_INT_XLEN_MAX  | Maximum value of int_xlen_t          |
+| __RISCV_INT_XLEN_MIN  | Minimum value of int_xlen_t          |
+| __RISCV_UINT_XLEN_MAX | Maximum value of uint_xlen_t         |
+| __RISCV_PRIdXLEN      | Expand to a string literal for use as a `d` print specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIiXLEN      | Expand to a string literal for use as a `i` print specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIoXLEN      | Expand to a string literal for use as a `o` print specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIuXLEN      | Expand to a string literal for use as a `u` print specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIxXLEN      | Expand to a string literal for use as a `x` print specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_PRIXXLEN      | Expand to a string literal for use as a `X` print specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNdXLEN      | Expand to a string literal for use as a `d` scan specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNiXLEN      | Expand to a string literal for use as a `i` scan specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNoXLEN      | Expand to a string literal for use as a `o` scan specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNuXLEN      | Expand to a string literal for use as a `u` scan specificier for int_xlen_t/uint_xlen_t. |
+| __RISCV_SCNxXLEN      | Expand to a string literal for use as a `x` scan specificier for int_xlen_t/uint_xlen_t. |
+
 
 ## Constraints on Operands of Inline Assembly Statements
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -246,12 +246,12 @@ marco could be used in intrinsic interface or user program directly.
 
 | Type Name             | Meaning                              |
 | --------------------- | ------------------------------------ |
-| int_xlen_t            | Signed integer type with XLEN bits   |
-| uint_xlen_t           | Unsigned integer type with XLEN bits |
+| int_xlen_t            | Two's-complement signed integer type with exactly XLEN bits (no padding bits)   |
+| uint_xlen_t           | Unsigned integer type with exactly XLEN bits (no padding bits) |
 
 | Macro Name            | Value                                |
 | --------------------- | ------------------------------------ |
-| INT_XLEN_MAX          | Minimum value of int_xlen_t          |
+| INT_XLEN_MAX          | Maximum value of int_xlen_t          |
 | INT_XLEN_MIN          | Minimum value of int_xlen_t          |
 | UINT_XLEN_MAX         | Maximum value of uint_xlen_t         |
 | UINT_XLEN_MIN         | Minimum value of uint_xlen_t         |


### PR DESCRIPTION
This PR is the product of this [RFC](https://github.com/riscv/riscv-elf-psabi-doc/issues/158)[1], the main purpose is provide a pair of integer type with XLEN-bits.

According the discussion, many people are concern about we should not add the type directly, that will corrupt the global namespace, so it would be great if we put it in the header files.

So why it put in `riscv_intrinsic.h`? here is two reason, first reason is the initial request are come from intrinsic function interface, so put they together should be reasonable, second reason is I have no idea which file name is the best :P `riscv.h` is little bit too generic and sounds like easy to conflict with exist headers - as I know at least gcc, binutils and gdb has one.

[1] https://github.com/riscv/riscv-elf-psabi-doc/issues/158