### PR TITLE
Add misc macro for vector extensions.

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -40,6 +40,60 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_flen        | <ul><li>32 if the F extension is available **or**</li><li>64 if `D` extension available **or**</li><li>128 if `Q` extension available</li></ul> | `F` extension is available. |
 | __riscv_32e         | 1     | `E` extension is available.   |
 | __riscv_vector      | 1     | Implies that any of the vector extensions (`v` or `zve*`) is available |
+| __riscv_v_min_vlen    | <N> (see [__riscv_v_min_vlen](#__riscv_v_min_vlen)) | The `V` extension or one of the `Zve*` extensions is available. |
+| __riscv_v_elen     | <N> (see [__riscv_v_elen](#__riscv_v_elen)) | The `V` extension or one of the `Zve*` extensions is available. |
+| __riscv_v_elen_fp  | <N> (see [__riscv_v_elen_fp](#__riscv_v_elen_fp)) | The `V` extension or one of the `Zve*` extensions is available. |
+
+### __riscv_v_min_vlen
+
+The `__riscv_v_min_vlen` macro expands to the minimal VLEN, in bits, mandated
+by the available vector extension, if any.
+
+The value of `__riscv_v_min_vlen` is defined by the following rules:
+- 128, if the `V` extension is present;
+- 32, if one of the `Zve32{x,f}` extensions is present;
+- 64, if one of the `Zve64{x,f,d}` extensions is present;
+- `N`, if one of the `Zvl<N>b` extensions, `N` in `{32,64,128,256,512,1024}`,
+is present.
+
+If multiple rules apply, the maximum value is taken.
+If none of the rules apply, `__riscv_v_min_vlen` is undefined.
+
+Examples:
+
+- `__riscv_v_min_vlen` is 128 for `rv64gcv`
+- `__riscv_v_min_vlen` is 512 for `rv32gcv_zvl512b`
+- `__riscv_v_min_vlen` is 256 for `rv32gcv_zvl32b_zvl256b`
+- `__riscv_v_min_vlen` is 128 for `rv64gcv_zvl32b`
+
+### __riscv_v_elen
+
+The `__riscv_v_elen` macro expands to the supported element length, in bits,
+of any non-floating-point vector operand of any vector instruction in the
+available vector extension, if any. (Stricter upper bounds may apply to
+particular operands of particular instructions.)
+
+
+The value of `__riscv_v_elen` is defined by the following rules:
+- 64, if the `V` extension or one of the `Zve64{x,f,d}` extensions is present; and
+- 32, if one of the `Zve32{x,f}` extensions is present.
+If multiple rules apply, the maximum value is taken.
+If none of the rules apply, `__riscv_v_elen` is undefined.
+
+### __riscv_v_elen_fp
+
+The `__riscv_v_elen_fp` macro expands to the supported element length, in bits,
+of any floating-point vector operand of any vector instruction in the available
+vector extension, if any. (Stricter upper bounds may apply to particular
+operands of particular instructions.)
+
+The value of `__riscv_v_elen_fp` is defined by the following rules:
+- 64, if one of the `V` or `Zve64d` extensions is present;
+- 32, if one of the `Zve{32,64}f` extensions is present; and
+- 0, if one of the `Zve{32,64}x` extensions is present.
+If multiple rules apply, the maximum value is taken.
+If none of the rules apply, `__riscv_v_elen_fp` is undefined.
+
 
 ### Architecture Extension Test Macro
 


### PR DESCRIPTION
Changes:
2021/08/19: Apply Fraser's fix.
2021/08/19: Change prefix to `__riscv_v_`

---

Background

RVV 1.0 has add few more extension (`zvl*b` and `zve*`) to give the promise about the EEW and VLEN, and this PR intend to expose those info by predefined marco.

https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#sec-vector-extensions

---
Introduce `__riscv_v_min_vlen`, `__riscv_v_max_eew` and `__riscv_v_max_eew_fp`
macro, for let programer easier to get vector related information, like:

- What's the minimal VLEN value is guaranteed current architecture
  extension?
- What's the maximal available EEW is guaranteed current
  architecture extension?
- What's the maximal available EEW for floating-point operation is
  guaranteed current architecture extension?

It's possible to get the information by testing serveral architecture extension
test macro, but the life can be simpler if toolchain can help, for
example, if you want to check the minimal VLEN value via those macro:

```c
 #if defined(__riscv_zvl512b)
   #define __riscv_v_min_vlen 512
 #elif defined(__riscv_zvl256b)
   #define __riscv_v_min_vlen 256
 #elif defined(__riscv_zvl128b) || defined(__riscv_v)
   #define __riscv_v_min_vlen 128
 #elif defined(__riscv_zvl64b) || defined(__riscv_zve64x) || \
       defined(__riscv_zve64f) || defined(__riscv_zve64d)
   #define __riscv_v_min_vlen 64
 #elif defined(__riscv_zvl32b) || defined(__riscv_zve32x) || \
       defined(__riscv_zve32f)
   #define __riscv_v_min_vlen 32
 #endif

```

And it's not scalable solution since in theory we can have up to zvl32768b...