### PR TITLE
Zawrs: Define extension availability macro

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -124,6 +124,7 @@ For example:
 | __riscv_c               | Arch Version | `C` extension is available.   |
 | __riscv_p               | Arch Version | `P` extension is available.   |
 | __riscv_v               | Arch Version | `V` extension is available.   |
+| __riscv_zawrs           | Arch Version | `Zawrs` extension is available. |
 | __riscv_zba             | Arch Version | `Zba` extension is available. |
 | __riscv_zbb             | Arch Version | `Zbb` extension is available. |
 | __riscv_zbc             | Arch Version | `Zbc` extension is available. |


### PR DESCRIPTION
This patch defines an availability macro for the Zawrs extension.

Note, that Zawrs is not frozen or ratified yet. I.e. this is an RFC for the time being.