### PR TITLE
Adding target attribute for function.

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -203,6 +203,65 @@ function declares more than one mode or an undefined mode.
 
 This attribute is incompatible with the `naked` attribute.
 
+### `__attribute__((target("<ATTR-STRING>")))`
+
+`target` attribute used for enable or disable a set of features or extensions
+for the fucntion.
+
+Function with target attribute should not affect the file scope build
+attributes, i.g. File complied with -march=rv64ima and a function declares with
+`__attribute__((target("arch=+zbb")))`, the `Tag_RISCV_arch` build attribute
+should be `rv64ima` rather than `rv64ima_zbb`.
+
+The compiler may emit mapping symbol at the beginning of the function with
+target attribute if the function use different set of ISA extension.
+
+`<ATTR-STRING>` can be specify following target attributes:
+
+- `arch=`: Adding extra extensions, omit certain extension, or specific
+           extension setting for the function.
+- `tune=`: Specify the pipeline mode and cost model with specific
+           microarchitecture or core for the function.
+- `cpu=`: Specify the pipeline mode, cost model and extension setting for the
+          function.
+
+The syntax of `<ATTR-STRING>` describes below:
+
+```
+ATTR-STRING := ATTR ';' ATTR
+             | ATTR
+
+ATTR        := ARCH-ATTR
+             | CPU-ATTR
+             | TUNE-ATTR
+
+ARCH-ATTR   := 'arch=' EXTENSIONS-OR-FULLARCH
+
+EXTENSIONS-OR-FULLARCH := <EXTENSIONS>
+                        | <FULLARCHSTR>
+
+EXTENSIONS             := <EXTENSION> ',' <EXTENSIONS>
+                        | <EXTENSION>
+
+FULLARCHSTR            := <full-arch-string>
+
+EXTENSION              := <OP> <EXTENSION-NAME> <VERSION>
+
+OP                     := '+'
+                        | '-'
+
+VERSION                := [0-9]+ 'p' [0-9]+
+                        | [1-9][0-9]*
+                        |
+
+EXTENSION-NAME         := Naming rule is defined in RISC-V ISA manual
+
+CPU-ATTR    := 'cpu=' <valid-cpu-name>
+TUNE-ATTR   := 'tune=' <valid-tune-name>
+```
+
+NOTE: The `target` attribute won't effect function name mangling for both C and C++.
+
 ## Intrinsic Functions
 
 Intrinsic functions (or intrinsics or built-ins) are expanded into instruction sequences by compilers.

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -248,9 +248,14 @@ equivalent to `arch=rv64g;tune=sifive-7-series`, and
 `cpu=sifive-u74;tune=sifive-5-series` is equivalent to
 `arch=rv64gc;tune=sifive-5-series`.
 
-If the same type of attribute is specified more than once, only the latest one
-takes effect. For example, `arch=+zbb;arch=+zba` will be equivalent to
-`arch=+zba`.
+The compiler should emit error if the same type of attribute is specified more
+than once. For example, `arch=+zbb;arch=+zba`, compiler should emit error
+because `arch` has specified twice.
+
+The compiler should emit errof if target attribute has specified more than once.
+For example,
+`__attribute__((target("arch=+v"))) __attribute__((target("arch=+zbb"))) int foo(int a)`
+, compiler should emit error because target attribute has specified twice.
 
 The interactions between the attribute and the command-line option are
 specified below:

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -303,6 +303,15 @@ CPU-ATTR    := 'cpu=' <valid-cpu-name>
 TUNE-ATTR   := 'tune=' <valid-tune-name>
 ```
 
+The target attribute does not support multi-versioning. The compiler should
+emit an error if a function is defined more than once. For example, the
+following code should trigger an error because foo is declared twice:
+
+```
+__attribute__((target("arch=+v"))) int foo(void) { return 0; }
+__attribute__((target("arch=+zbb"))) int foo(void) { return 1; }
+```
+
 ## Intrinsic Functions
 
 Intrinsic functions (or intrinsics or built-ins) are expanded into instruction sequences by compilers.

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -248,7 +248,6 @@ FULLARCHSTR            := <full-arch-string>
 EXTENSION              := <OP> <EXTENSION-NAME> <VERSION>
 
 OP                     := '+'
-                        | '-'
 
 VERSION                := [0-9]+ 'p' [0-9]+
                         | [1-9][0-9]*

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -254,8 +254,6 @@ takes effect. For example, `arch=+zbb;arch=+zba` will be equivalent to
 The interactions between the attribute and the command-line option are
 specified below:
 
-Here's a refined version of your statement:
-
 - `arch=`: Its behavior depends on the syntax used:
            1) Adding extra extensions: It will merge the extension list with the `-march` option.
            2) If a full architecture string is specified by `arch=`, it will override the `-march` option.

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -208,8 +208,20 @@ This attribute is incompatible with the `naked` attribute.
 `target` attribute used for enable or disable a set of features or extensions
 for the fucntion.
 
+For instance, you can enable the `v` extension for a specific function even if
+`-march` or `-mcpu` does not include the `v` extension. Additionally,
+this won't alter the global setting.
+```c
+__attribute__((target("+v")))
+int
+foo (int a)
+{
+  return a + 5;
+}
+```
+
 Function with target attribute should not affect the file scope build
-attributes, i.g. File complied with -march=rv64ima and a function declares with
+attributes, i.g. File complied with `-march=rv64ima` and a function declares with
 `__attribute__((target("arch=+zbb")))`, the `Tag_RISCV_arch` build attribute
 should be `rv64ima` rather than `rv64ima_zbb`.
 
@@ -225,10 +237,22 @@ target attribute if the function use different set of ISA extension.
 - `cpu=`: Specify the pipeline mode, cost model and extension setting for the
           function.
 
+The interactions among `arch`, `tune`, and `cpu` are the same as the `-march`,
+`-mtune`, and `-mcpu` options. The `cpu` can be treated as a combination of
+`arch` + `tune` but has a lower priority than the other two. For instance,
+`cpu=sifive-u74` is equivalent to `arch=rv64gc` and `tune=sifive-7-series`.
+However, if `arch=` or `tune=` values are provided, they will override the `cpu`
+value. Therefore, `cpu=sifive-u74;arch=rv64g` will be equivalent to
+`arch=rv64g;tune=sifive-7-series`, and `cpu=sifive-u74;tune=sifive-5-series`
+will be equivalent to `arch=rv64gc;tune=sifive-5-series`.
+
+If the same type of attribute is given more than once, only the latest one
+takes effect, e.g. `arch=+zbb;arch=+zba` will be equivalent to `arch=+zba`.
+
 The syntax of `<ATTR-STRING>` describes below:
 
 ```
-ATTR-STRING := ATTR ';' ATTR
+ATTR-STRING := ATTR-STRING ';' ATTR
              | ATTR
 
 ATTR        := ARCH-ATTR
@@ -260,6 +284,8 @@ TUNE-ATTR   := 'tune=' <valid-tune-name>
 ```
 
 NOTE: The `target` attribute won't effect function name mangling for both C and C++.
+NOTE: The compiler should always generate the function with the `target`
+attribute, even if it produces the same code without the attribute.
 
 ## Intrinsic Functions
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -205,8 +205,8 @@ This attribute is incompatible with the `naked` attribute.
 
 ### `__attribute__((target("<ATTR-STRING>")))`
 
-The `target` attribute is used to enable or disable a set of features or
-extensions for a function.
+The `target` attribute is used to enable a set of features or extensions for a
+function.
 
 For instance, you can enable the `v` extension for a specific function even if
 the `-march` or `-mcpu` options do not include the `v` extension. Importantly,
@@ -230,7 +230,7 @@ target attribute if the function utilizes a different set of ISA extensions.
 
 `<ATTR-STRING>` can specify the following target attributes:
 
-- `arch=`: Adds extra extensions and overrides the `-march` value specified via
+- `arch=`: Adds extra extensions or overrides the `-march` value specified via
            the command line for the function.
 - `tune=`: Specifies the pipeline model and cost model associated with a
            specific microarchitecture or core for the function.
@@ -254,9 +254,11 @@ takes effect. For example, `arch=+zbb;arch=+zba` will be equivalent to
 The interactions between the attribute and the command-line option are
 specified below:
 
-- `arch=`: Combines the extension list with the `-march` option; however,
-           it necessitates overriding the `-march` option if a full architecture
-           string is specified by `arch=`.
+Here's a refined version of your statement:
+
+- `arch=`: Its behavior depends on the syntax used:
+           1) Adding extra extensions: It will merge the extension list with the `-march` option.
+           2) If a full architecture string is specified by `arch=`, it will override the `-march` option.
 - `tune=`: Overrides the `-mtune` option and the pipeline model and cost model
            part of `-mcpu`.
 - `cpu=`: Overrides the `-mcpu` option, overrides the `-mtune` option if `tune=`
@@ -296,12 +298,6 @@ EXTENSION-NAME         := Naming rule is defined in RISC-V ISA manual
 CPU-ATTR    := 'cpu=' <valid-cpu-name>
 TUNE-ATTR   := 'tune=' <valid-tune-name>
 ```
-
-NOTE: The compiler should always generate the function with the `target`
-attribute, even if it would produce the same code without the attribute.
-For instance, when the function `foo` with `__attribute__((target("arch=+g")))`
-is compiled with `-march=rv64gc`, it will produce identical output, but the
-compiler should still generate the function.
 
 ## Intrinsic Functions
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -220,12 +220,13 @@ int foo(int a)
 }
 ```
 
-Using the `target` attribute for a function should not affect the file scope
+Using the `target` attribute for a function should not affect the translation unit scope
 build attributes. For example, if a file is compiled with `-march=rv64ima` and
 a function is declared with `__attribute__((target("arch=+zbb")))`, the
 `Tag_RISCV_arch` build attribute should remain `rv64ima`, not `rv64ima_zbb`.
 
-The compiler may emit a mapping symbol at the beginning of a function with the
+The compiler may emit a [mapping symbol](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#mapping-symbol)
+at the beginning of a function with the
 target attribute if the function utilizes a different set of ISA extensions.
 
 `<ATTR-STRING>` can specify the following target attributes:

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -212,7 +212,7 @@ For instance, you can enable the `v` extension for a specific function even if
 `-march` or `-mcpu` does not include the `v` extension. Additionally,
 this won't alter the global setting.
 ```c
-__attribute__((target("+v")))
+__attribute__((target("arch=+v")))
 int
 foo (int a)
 {
@@ -221,7 +221,7 @@ foo (int a)
 ```
 
 Function with target attribute should not affect the file scope build
-attributes, i.g. File complied with `-march=rv64ima` and a function declares with
+attributes, e.g. File compiled with `-march=rv64ima` and a function declares with
 `__attribute__((target("arch=+zbb")))`, the `Tag_RISCV_arch` build attribute
 should be `rv64ima` rather than `rv64ima_zbb`.
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -205,49 +205,63 @@ This attribute is incompatible with the `naked` attribute.
 
 ### `__attribute__((target("<ATTR-STRING>")))`
 
-`target` attribute used for enable or disable a set of features or extensions
-for the fucntion.
+The `target` attribute is used to enable or disable a set of features or
+extensions for a function.
 
 For instance, you can enable the `v` extension for a specific function even if
-`-march` or `-mcpu` does not include the `v` extension. Additionally,
-this won't alter the global setting.
+the `-march` or `-mcpu` options do not include the `v` extension. Importantly,
+this won't alter the global settings. Here is an example:
+
 ```c
 __attribute__((target("arch=+v")))
-int
-foo (int a)
+int foo(int a)
 {
   return a + 5;
 }
 ```
 
-Function with target attribute should not affect the file scope build
-attributes, e.g. File compiled with `-march=rv64ima` and a function declares with
-`__attribute__((target("arch=+zbb")))`, the `Tag_RISCV_arch` build attribute
-should be `rv64ima` rather than `rv64ima_zbb`.
+Using the `target` attribute for a function should not affect the file scope
+build attributes. For example, if a file is compiled with `-march=rv64ima` and
+a function is declared with `__attribute__((target("arch=+zbb")))`, the
+`Tag_RISCV_arch` build attribute should remain `rv64ima`, not `rv64ima_zbb`.
 
-The compiler may emit mapping symbol at the beginning of the function with
-target attribute if the function use different set of ISA extension.
+The compiler may emit a mapping symbol at the beginning of a function with the
+target attribute if the function utilizes a different set of ISA extensions.
 
-`<ATTR-STRING>` can be specify following target attributes:
+`<ATTR-STRING>` can specify the following target attributes:
 
-- `arch=`: Adding extra extensions, omit certain extension, or specific
-           extension setting for the function.
-- `tune=`: Specify the pipeline mode and cost model with specific
-           microarchitecture or core for the function.
-- `cpu=`: Specify the pipeline mode, cost model and extension setting for the
-          function.
+- `arch=`: Adds extra extensions and overrides the `-march` value specified via
+           the command line for the function.
+- `tune=`: Specifies the pipeline model and cost model associated with a
+           specific microarchitecture or core for the function.
+- `cpu=`: Specifies the pipeline mode, cost model, and extension settings for
+          the function.
 
-The interactions among `arch`, `tune`, and `cpu` are the same as the `-march`,
-`-mtune`, and `-mcpu` options. The `cpu` can be treated as a combination of
-`arch` + `tune` but has a lower priority than the other two. For instance,
-`cpu=sifive-u74` is equivalent to `arch=rv64gc` and `tune=sifive-7-series`.
-However, if `arch=` or `tune=` values are provided, they will override the `cpu`
-value. Therefore, `cpu=sifive-u74;arch=rv64g` will be equivalent to
-`arch=rv64g;tune=sifive-7-series`, and `cpu=sifive-u74;tune=sifive-5-series`
-will be equivalent to `arch=rv64gc;tune=sifive-5-series`.
+The interactions among the `arch`, `tune`, and `cpu` attributes mirror those of
+the `-march`, `-mtune`, and `-mcpu` options. The `cpu` attribute can be seen as
+a combination of `arch` + `tune` but holds a lower priority than the other two.
+For instance, `cpu=sifive-u74` equates to `arch=rv64gc` and
+`tune=sifive-7-series`. However, if values for `arch=` or `tune=` are provided,
+they will override the `cpu` value. Therefore, `cpu=sifive-u74;arch=rv64g` is
+equivalent to `arch=rv64g;tune=sifive-7-series`, and
+`cpu=sifive-u74;tune=sifive-5-series` is equivalent to
+`arch=rv64gc;tune=sifive-5-series`.
 
-If the same type of attribute is given more than once, only the latest one
-takes effect, e.g. `arch=+zbb;arch=+zba` will be equivalent to `arch=+zba`.
+If the same type of attribute is specified more than once, only the latest one
+takes effect. For example, `arch=+zbb;arch=+zba` will be equivalent to
+`arch=+zba`.
+
+The interactions between the attribute and the command-line option are
+specified below:
+
+- `arch=`: Combines the extension list with the `-march` option; however,
+           it necessitates overriding the `-march` option if a full architecture
+           string is specified by `arch=`.
+- `tune=`: Overrides the `-mtune` option and the pipeline model and cost model
+           part of `-mcpu`.
+- `cpu=`: Overrides the `-mcpu` option, overrides the `-mtune` option if `tune=`
+          is not present, and overrides the `-march` option if `arch=` is not
+          present.
 
 The syntax of `<ATTR-STRING>` describes below:
 
@@ -283,9 +297,11 @@ CPU-ATTR    := 'cpu=' <valid-cpu-name>
 TUNE-ATTR   := 'tune=' <valid-tune-name>
 ```
 
-NOTE: The `target` attribute won't effect function name mangling for both C and C++.
 NOTE: The compiler should always generate the function with the `target`
-attribute, even if it produces the same code without the attribute.
+attribute, even if it would produce the same code without the attribute.
+For instance, when the function `foo` with `__attribute__((target("arch=+g")))`
+is compiled with `-march=rv64gc`, it will produce identical output, but the
+compiler should still generate the function.
 
 ## Intrinsic Functions
 


### PR DESCRIPTION
After adding mapping symbol and `.option arch`, finally we have
all necessary components of function multi-versioning.

This proposal has add a new funciton attribte: `target` attribte for compile a
funciton with specify extension, pipeline model or cost model, could be used as
simple`*` function multi-versioning.

`*`: Simple is compare to `target_clones` in x86 and `target_version` in
AArch64, and also require user to dispatch that right.

It similar to AArch64's target attribte: https://gcc.gnu.org/onlinedocs/gcc/AArch64-Function-Attributes.html

This attribte won't change the function name mangling, and also require
do not update Tag_RISCV_arch attribte.

Ref:
- https://maskray.me/blog/2023-02-05-function-multi-versioning

---

NOTE: This PR will not be merged until we have PoC *AND* GNU/LLVM community reach consensus 
NOTE: We don't have PoC for either GCC and clang yet, 