### PR TITLE
Add inline asm operand constraints for vector register

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -230,6 +230,9 @@ statements, including both RISC-V specific and common operand constraints.
 | I                  | 12-bit signed immediate integer operand      |      |
 | K                  | 5-bit unsigned immediate integer operand     |      |
 | J                  | Zero integer immediate operand                |      |
+| vr                 | Vector register                    |            |
+| vd                 | Vector register, excluding v0      |            |
+| vm                 | Vector register, only v0           |            |
 
 NOTE: Immediate value must be a compile-time constant.
 


### PR DESCRIPTION
We have 3 common operand constraints constraint between GCC and LLVM here:

- vr: Any vector register, v0-v31
- vd: Any vector register, excluding v0, used for avoid overlapping with mask register.
- vm: Mask vector register, only v0.