### PR TITLE
Introduce new constraint for register pair

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -225,6 +225,7 @@ statements, including both RISC-V specific and common operand constraints.
 | m                  | An address that is held in a general-purpose register with offset.      |      |
 | A                  | An address that is held in a general-purpose register.      |      |
 | r                  | General purpose register                      |      |
+| R                  | Register pair for GPR, and it must start with an even-numbered register.   |      |
 | f                  | Floating-point register                       |      |
 | i                  | Immediate integer operand                     |      |
 | I                  | 12-bit signed immediate integer operand      |      |


### PR DESCRIPTION
Must start with an even-numbered register.


NOTE: This is *NOT* implemented on either on LLVM or GCC yet, this PR will hold until at least one compiler has implemented.

Fix #37 