### PR TITLE
Document operand modifier

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -300,3 +300,13 @@ bar:
 
 The compiler uses an immediate offset of 40 for the `m` constraint, but for the
 `A` constraint uses an extra addi instruction instead.
+
+### Operand Modifiers
+
+This section lists operand modifiers that can be used with inline assembly
+statements, including both RISC-V specific and common operand modifiers.
+
+| Modifiers    | Description                                                                       | Note        |
+| ------------ | --------------------------------------------------------------------------------- | ----------- |
+| z            | Print `zero` (`x0`) register for immediate 0, typically used with constraints `J` |             |
+| i            | Print `i` if corresponding operand is immediate.                                  |             |


### PR DESCRIPTION
- Document `z` and `i`, which has implemented on both LLVM and GCC.

---

@topperc fixed a GCC compatible issue on `r` constraint with 0 immediate[1], and I found we didn't well document those operand modifier any where including GCC document...so I think it would be great to start document this some where, and here should be a good starter.

[1] https://reviews.llvm.org/D154744

cc @asb