### PR TITLE
Locality for prefetch built-in proposal

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -402,15 +402,15 @@ enum {
 
 ### Prefetch Intrinsics
 
-The zicbop extension provide the prefetch instruction to allow users to optimize data access patterns by providing hints to the hardware regarding future data accesses. It is supported through a compiler-defined built-in function with three arguments that specify its behavior.
+The Zicbop extension provide the prefetch instruction to allow users to optimize data access patterns by providing hints to the hardware regarding future data accesses. It is supported through a compiler-defined built-in function with three arguments that specify its behavior.
 
 ```
 void __builtin_prefetch(const void *addr, int rw, int locality)
 ```
 
-The locality for the built-in __builtin_prefetch function in RISC-V can be achieved using the Non-Temporal Locality Hints (NTLH) extension. According to Non-Temporal Locality Hints extension, it indicates that a cache line should be prefetched into a cache that is outer from the level specified by the NTL when a NTL instruction is applied to prefetch instruction.
+The locality for the built-in `__builtin_prefetch` function in RISC-V can be achieved using the Non-Temporal Locality Hints (Zihintntl) extension. According to Non-Temporal Locality Hints extension, it indicates that a cache line should be prefetched into a cache that is outer from the level specified by the NTL when a NTL instruction is applied to prefetch instruction.
 
-The following table presents the mapping from the __builtin_prefetch function to the corresponding assembly instructions using the NTL extension.
+The following table presents the mapping from the `__builtin_prefetch` function to the corresponding assembly instructions assuming the presence of the Zihintntl and Zicbop extensions.
 
 | Prefetch function                               | Assembly                     | 
 | ----------------------------------------------- | ---------------------------- | 
@@ -418,8 +418,6 @@ The following table presents the mapping from the __builtin_prefetch function to
 | `__builtin_prefetch(ptr, 0, 1 /* locality */);` | `ntl.pall + prefetch.r (ptr)`|
 | `__builtin_prefetch(ptr, 0, 2 /* locality */);` | `ntl.p1 + prefetch.r (ptr)`  |
 | `__builtin_prefetch(ptr, 0, 3 /* locality */);` | `prefetch.r (ptr)`           |
-
-Compiler only emits the ntlh hints if the Zihintntl extension is enabled.
 
 ### Scalar Bit Manipulation Extension Intrinsics
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -402,13 +402,13 @@ enum {
 
 ### Prefetch Intrinsics
 
-The Zicbop extension provide the prefetch instruction to allow users to optimize data access patterns by providing hints to the hardware regarding future data accesses. It is supported through a compiler-defined built-in function with three arguments that specify its behavior.
+The Zicbop extension provides the prefetch instruction to allow users to optimize data access patterns by providing hints to the hardware regarding future data accesses. It is supported through a compiler-defined built-in function with three arguments that specify its behavior.
 
 ```
 void __builtin_prefetch(const void *addr, int rw, int locality)
 ```
 
-The locality for the built-in `__builtin_prefetch` function in RISC-V can be achieved using the Non-Temporal Locality Hints (Zihintntl) extension. According to Non-Temporal Locality Hints extension, it indicates that a cache line should be prefetched into a cache that is outer from the level specified by the NTL when a NTL instruction is applied to prefetch instruction.
+The locality for the built-in `__builtin_prefetch` function in RISC-V can be achieved using the Non-Temporal Locality Hints (Zihintntl) extension. When a Non-Temporal Locality (NTL) Hints instruction is applied to prefetch instruction, a cache line should be prefetched into a cache level that is higher than the level specified by the NTL.
 
 The following table presents the mapping from the `__builtin_prefetch` function to the corresponding assembly instructions assuming the presence of the Zihintntl and Zicbop extensions.
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -419,6 +419,8 @@ The following table presents the mapping from the __builtin_prefetch function to
 | `__builtin_prefetch(ptr, 0, 2 /* locality */);` | `ntl.p1 + prefetch.r (ptr)`  |
 | `__builtin_prefetch(ptr, 0, 3 /* locality */);` | `prefetch.r (ptr)`           |
 
+Compiler only emits the ntlh hints if the Zihintntl extension is enabled.
+
 ### Scalar Bit Manipulation Extension Intrinsics
 
 In order to access the RISC-V scalar bit manipulation intrinsics, it is

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -400,6 +400,25 @@ enum {
 | `__RISCV_NTLH_INNERMOST_SHARED`  | `ntl.s1`    |
 | `__RISCV_NTLH_ALL`               | `ntl.all`   |
 
+### Prefetch Intrinsics
+
+The zicbop extension provide the prefetch instruction to allow users to optimize data access patterns by providing hints to the hardware regarding future data accesses. It is supported through a compiler-defined built-in function with three arguments that specify its behavior.
+
+```
+void __builtin_prefetch(const void *addr, int rw, int locality)
+```
+
+The locality for the built-in __builtin_prefetch function in RISC-V can be achieved using the Non-Temporal Locality Hints (NTLH) extension. According to Non-Temporal Locality Hints extension, it indicates that a cache line should be prefetched into a cache that is outer from the level specified by the NTL when a NTL instruction is applied to prefetch instruction.
+
+The following table presents the mapping from the __builtin_prefetch function to the corresponding assembly instructions using the NTL extension.
+
+| Prefetch function                               | Assembly                     | 
+| ----------------------------------------------- | ---------------------------- | 
+| `__builtin_prefetch(ptr, 0, 0 /* locality */);` | `ntl.all + prefetch.r (ptr)` |
+| `__builtin_prefetch(ptr, 0, 1 /* locality */);` | `ntl.pall + prefetch.r (ptr)`|
+| `__builtin_prefetch(ptr, 0, 2 /* locality */);` | `ntl.p1 + prefetch.r (ptr)`  |
+| `__builtin_prefetch(ptr, 0, 3 /* locality */);` | `prefetch.r (ptr)`           |
+
 ### Scalar Bit Manipulation Extension Intrinsics
 
 In order to access the RISC-V scalar bit manipulation intrinsics, it is
@@ -500,6 +519,7 @@ Sign extension of 32-bit values on RV64 is not reflected in the interface.
 | `uint32_t __riscv_sm3p1(uint32_t rs1);`                                 | `sm3p1`       | Zksh              | |
 | `uint32_t __riscv_sm4ed(uint32_t rs1, uint32_t rs2, const int bs);`     | `sm4ed`       | Zksed             | `bs`=[0..3] |
 | `uint32_t __riscv_sm4ks(uint32_t rs1, uint32_t rs2, const int bs);`     | `sm4ks`       | Zksed             | `bs`=[0..3] |
+
 
 ## Constraints on Operands of Inline Assembly Statements
 


### PR DESCRIPTION
ARM[1] provide the its own semantic on prefetch built-in locality.

It seem we could do the same thing in RISC-V.

[1] https://developer.arm.com/documentation/101458/2010/Coding-best-practice/Prefetching-with---builtin-prefetch