### PR TITLE
Function multi-version proposal

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -319,7 +319,7 @@ EXTENSION-NAME         := Naming rule is defined in RISC-V ISA manual
 For example, the following `foo` function will have three versions but share the same function signature.
 
 ```c
-__attribute__((target_clones("arch=+v", "default", "arch=rv64gc_zbb")))
+__attribute__((target_clones("arch=+v", "default", "arch=+zbb")))
 int foo(int a)
 {
   return a + 5;


### PR DESCRIPTION
During the Function multi-version dispatch the function, we need a method to retrieve the RISC-V hardware environment to make sure all extension must be available.

The problem is

* How to implement this function
* Where to provide this function

From the compiler's view, it will generate the IFUNC resolver when there are more than one implementation with the same symbol name.

Consider following example:

```
__attribute__((target("default"))) int foo (int index)
{
  return index;
}

__attribute__((target("arch=rv64gc"))) int foo (int index)
{
 return index;
}

void bar() {
  foo(0);
}
```

The corresponding assembly will look like:

```
bar() {
(foo.ifunc())(0);
}

.set foo.ifunc, foo.resolver

func_ptr foo.resolver() {
  if (__riscv_ifunc_select("m_a_f_d_c"))
    return ptr foo.m_a_f_d_c;
  return ptr foo.default;
}

int foo.default(int index) {
	...
}

int foo.m_a_f_d_c(int index) {
	...
}
```

The resolver that the compiler generates query and selects for each candidate function. When fulfilling the requirement, then return the corresponding function ptr for further processing.

In this proposal, the major part of the resolver function is `__riscv_ifunc_select`. `__riscv_ifunc_select` must retrieve the hardware information for deciding whether to execute the specific function.

Here we propose that function as the following declaration

```
bool __riscv_ifunc_select(char *FeatureStr);
```

Where FeatureString is a string that concatenates all target features belonging to a particular function. The form can be described in the following BNF form.

When hardware fulfills the FeatureStr, then returns true. Otherwise this function returns false.

---
2023/09/04 Update: The following section take the linux platform as example for `__riscv_ifunc_select` implementation.

There are two ways to retrieve hardware information.

* RISC-V Hardware Probing Interface [1] 
    * Not fully cover all extensions, and need to sync the all defined symbol from linux kernel source code.
* /proc/cpuinfo isa string 
    * Not every system has the cpuinfo file.

Another problem is where to place the function definition.

The compiler-rt/libgcc is a good place to implement these functions, like other target(x86/aarch64) implementation.

[1] https://docs.kernel.org/riscv/hwprobe.html

---
2024/07/11 Update

1. Remain the syntax part, the runtime function move to another RFC.
2. Remove `arch=<full-arch-string>` from syntax