### PR TITLE
Clarify that slow misaligned accesses may be very slow

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -43,9 +43,9 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_v_min_vlen    | <N> (see [__riscv_v_min_vlen](#__riscv_v_min_vlen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen     | <N> (see [__riscv_v_elen](#__riscv_v_elen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen_fp  | <N> (see [__riscv_v_elen_fp](#__riscv_v_elen_fp)) | The `V` extension or one of the `Zve*` extensions is available. |
-| __riscv_misaligned_fast | 1  | Misaligned access on cpu are fast. |
-| __riscv_misaligned_slow | 1  | Misaligned access on cpu may not be as fast as aligned access. |
-| __riscv_misaligned_avoid | 1  | Misaligned access are not supported by cpu and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
+| __riscv_misaligned_fast | 1  | Misaligned access are fast. |
+| __riscv_misaligned_slow | 1  | Misaligned access may not be as fast as aligned access. |
+| __riscv_misaligned_avoid | 1  | Misaligned access are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
 
 ### __riscv_v_min_vlen
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -44,7 +44,7 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_v_elen     | <N> (see [__riscv_v_elen](#__riscv_v_elen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen_fp  | <N> (see [__riscv_v_elen_fp](#__riscv_v_elen_fp)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_misaligned_fast | 1  | Misaligned accesses are fast. |
-| __riscv_misaligned_slow | 1  | Misaligned accesses may not be as fast as aligned access. |
+| __riscv_misaligned_slow | 1  | Misaligned accesses are supported, but may be substantially slower than aligned accesses. |
 | __riscv_misaligned_avoid | 1  | Misaligned accesses are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
 
 ### __riscv_v_min_vlen

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -43,9 +43,9 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_v_min_vlen    | <N> (see [__riscv_v_min_vlen](#__riscv_v_min_vlen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen     | <N> (see [__riscv_v_elen](#__riscv_v_elen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen_fp  | <N> (see [__riscv_v_elen_fp](#__riscv_v_elen_fp)) | The `V` extension or one of the `Zve*` extensions is available. |
-| __riscv_misaligned_fast | 1  | Misaligned access are fast. |
-| __riscv_misaligned_slow | 1  | Misaligned access may not be as fast as aligned access. |
-| __riscv_misaligned_avoid | 1  | Misaligned access are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
+| __riscv_misaligned_fast | 1  | Misaligned accesses are fast. |
+| __riscv_misaligned_slow | 1  | Misaligned accesses may not be as fast as aligned access. |
+| __riscv_misaligned_avoid | 1  | Misaligned accesses are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
 
 ### __riscv_v_min_vlen
 


### PR DESCRIPTION
The current description might give some people the impression that misaligned accesses are only a little bit slower than aligned ones.  But the intent is for the "slow" macro to be defined when the accesses are legal, but potentially extremely slow.

By contrast, the "fast" macro should be defined when misaligned accesses are reasonably fast, even if they're a little bit slower than misaligned ones.  So, the existing text for the "fast" case is fine.

This isn't really a normative change; it's a tweak to the shades of meaning in the description.