### PR TITLE
Add zicsr and zifencei to extension test macros

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -136,6 +136,8 @@ For example:
 | __riscv_c               | Arch Version | `C` extension is available.   |
 | __riscv_p               | Arch Version | `P` extension is available.   |
 | __riscv_v               | Arch Version | `V` extension is available.   |
+| __riscv_zicsr           | Arch Version | `Zicsr` extension is available. |
+| __riscv_zifencei        | Arch Version | `Zifencei` extension is available. |
 | __riscv_zawrs           | Arch Version | `Zawrs` extension is available. |
 | __riscv_zba             | Arch Version | `Zba` extension is available. |
 | __riscv_zbb             | Arch Version | `Zbb` extension is available. |


### PR DESCRIPTION
Adds the __riscv_zicsr and __riscv_zifencei extension test macros to the existing table.

cc @kito-cheng 