### PR TITLE
Add -m[no-]unaligned-access

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -21,7 +21,7 @@ https://creativecommons.org/licenses/by/4.0/.
 * `-mtune=MICRO_ARCHITECTURE`
 * `-mplt` `-mno-plt`
 * `-mcmodel=CODE_MODEL`
-* `-mstrict-align` `-mno-strict-align` `-munaligned-access` `-mnounaligned-access`
+* `-mstrict-align` `-mno-strict-align` `-munaligned-access` `-mno-unaligned-access`
 * `-mfdiv` `-mno-fdiv`
 * `-mdiv` `-mno-div`
 * `-mpreferred-stack-boundary=N`

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -21,7 +21,7 @@ https://creativecommons.org/licenses/by/4.0/.
 * `-mtune=MICRO_ARCHITECTURE`
 * `-mplt` `-mno-plt`
 * `-mcmodel=CODE_MODEL`
-* `-mstrict-align` `-mno-strict-align`
+* `-mstrict-align` `-mno-strict-align` `-munaligned-access` `-mnounaligned-access`
 * `-mfdiv` `-mno-fdiv`
 * `-mdiv` `-mno-div`
 * `-mpreferred-stack-boundary=N`
@@ -102,8 +102,9 @@ If none of the rules apply, `__riscv_v_elen_fp` is undefined.
 
 These can be used in common library code to compile time segregate code which relies
 on misaligned access being fast or not.
-A typical complier could (but not necessarily) map fast variant to -mno-strict-align
-and avoid to -mstrict-align, if specified.
+A typical complier could (but not necessarily) map fast variant to `-mno-strict-align`
+or `-munaligned-access` and avoid to `-mstrict-align` or `-mno-unaligned-access`, if
+specified.
 Perhaps obvious, but these are mutually exclusive, so only one is defined at a time
 for a compilation unit.
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -21,7 +21,7 @@ https://creativecommons.org/licenses/by/4.0/.
 * `-mtune=MICRO_ARCHITECTURE`
 * `-mplt` `-mno-plt`
 * `-mcmodel=CODE_MODEL`
-* `-mstrict-align` `-mno-strict-align` `-munaligned-access` `-mno-unaligned-access`
+* `-mstrict-align` `-mno-strict-align` and `-munaligned-access` `-mno-unaligned-access`
 * `-mfdiv` `-mno-fdiv`
 * `-mdiv` `-mno-div`
 * `-mpreferred-stack-boundary=N`
@@ -30,6 +30,10 @@ https://creativecommons.org/licenses/by/4.0/.
 * `-mrelax` `-mno-relax`
 * `-msave-restore` `-mno-save-restore`
 * `-mbranch-cost=N`
+
+NOTE: `-munaligned-access` and `-mno-unaligned-access` are provided to reduce migration
+efforts because some compiler implementations of other targets like ARM/AArch64/MIPS use
+these options.
 
 ## Preprocessor Definitions
 


### PR DESCRIPTION
These two options are negative equivalent to -m[no-]strict-align.
Clang/LLVM has supported both ways (same as AArch32/AArch64/LoongArch).
This can reduce some miscompiles when migrating some existed software packages.