### PR TITLE
Add missing `__riscv_q` predefine to riscv-c-api.md

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -134,6 +134,7 @@ For example:
 | __riscv_a               | Arch Version | `A` extension is available.   |
 | __riscv_f               | Arch Version | `F` extension is available.   |
 | __riscv_d               | Arch Version | `D` extension is available.   |
+| __riscv_q               | Arch Version | `Q` extension is available.   |
 | __riscv_c               | Arch Version | `C` extension is available.   |
 | __riscv_p               | Arch Version | `P` extension is available.   |
 | __riscv_v               | Arch Version | `V` extension is available.   |


### PR DESCRIPTION
The Q extension and its `__riscv_q` predefined macro are missing from the list, but compilers do actually define this alongside `__riscv_f` and `__riscv_d`.