### PR TITLE
Document constraint "s"

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -559,6 +559,7 @@ statements, including both RISC-V specific and common operand constraints.
 | I                  | 12-bit signed immediate integer operand      |      |
 | K                  | 5-bit unsigned immediate integer operand     |      |
 | J                  | Zero integer immediate operand                |      |
+| s                  | symbol or label reference with a constant offset |      |
 | vr                 | Vector register                    |            |
 | vd                 | Vector register, excluding v0      |            |
 | vm                 | Vector register, only v0           |            |


### PR DESCRIPTION
"s" can be used to create an artificial reference for linker garbage collection, or define sections to hold symbol addresses. "S" does not work for a preemptible symbol in GCC while "s" does.