### PR TITLE
Function attribute for standard vector calling convention variant: riscv_vector_cc

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -318,7 +318,14 @@ __attribute__((target("arch=+v"))) int foo(void) { return 0; }
 __attribute__((target("arch=+zbb"))) int foo(void) { return 1; }
 ```
 
-### `__attribute__((riscv_vector_cc))`
+### riscv_vector_cc
+
+Supported Syntaxes:
+| Style  | Syntax                              |
+| ------ | ----------------------------------- |
+| GNU    | `__attribute__((riscv_vector_cc)))` |
+| C++11  | `[[riscv::vector_cc]]`              |
+| C23    | `[[riscv::vector_cc]]`              |
 
 Functions declared with this attribute will use to the standard vector calling
 convention variant as defined in the RISC-V psABI, even if the function has

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -318,6 +318,12 @@ __attribute__((target("arch=+v"))) int foo(void) { return 0; }
 __attribute__((target("arch=+zbb"))) int foo(void) { return 1; }
 ```
 
+### `__attribute__((riscv_vector_cc))`
+
+Functions declared with this attribute will use to the standard vector calling
+convention variant as defined in the RISC-V psABI, even if the function has
+vector arguments or a return value.
+
 ## Intrinsic Functions
 
 Intrinsic functions (or intrinsics or built-ins) are expanded into instruction sequences by compilers.


### PR DESCRIPTION
Standard vector calling convention variant has landed in psABI now, and the implementation also merged into GCC trunk, LLVM part are also under reviewing, and this attribute has mentioned during the discussion, but seems like we don't document that yet.

---

Standard vector calling convention variant will only enabled when function has vector argument or returing value by default, however user may also want to invoke function without that during a vectorized loop at some situation, but it will cause a huge performance penalty due to vector register store/restore.

So user can declare function with this riscv_vector_cc attribute like below, that could enforce function will use standard vector calling convention variant.

```c
void foo() __attribute__((riscv_vector_cc));
[[riscv::vector_cc]] void foo(); // For C++11 and C23
```