### PR TITLE
Add atomic intrinsics

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -485,6 +485,17 @@ RISC-V intrinsics examples:
 vint8m1_t __riscv_vadd_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl); // vadd.vv vd, vs2, vs1
 ----
 
+### Atomic Intrinsics
+In order to access the RISC-V atomic intrinsics, it is necessary to include the
+header file `riscv_atomic.h`.
+The functions are only available if the compiler's `-march` string enables the
+required ISA extension.
+The following table contains all the atomic intrinsics:
+| Prototype                 | Instruction | Extension | Notes |
+| ---------                 | ----------- | --------- | ----- |
+| `void __riscv_wrs_nto();` | `wrs.nto`   | Zawrs     | |
+| `void __riscv_wrs_sto();` | `wrs.sto`   | Zawrs     | |
+
 === NTLH Intrinsics
 
 


### PR DESCRIPTION
We need this when optimizing some locks' implementation, but using inline assembly will stop some optimizations. For example, if we use inline assembly, the compiler doesn't know `lr.w` will sign-extend the result.

ARM provides similar intrinsics like `__builtin_arm_ldaex`.

Currently, we only add intrinsics for `Zawrs`.