### PR TITLE
Update __riscv_misaligned_* macros to refer to scalar only

### DIFF
--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -27,7 +27,7 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_v_min_vlen    | <N> (see [__riscv_v_min_vlen](#__riscv_v_min_vlen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen     | <N> (see [__riscv_v_elen](#__riscv_v_elen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen_fp  | <N> (see [__riscv_v_elen_fp](#__riscv_v_elen_fp)) | The `V` extension or one of the `Zve*` extensions is available. |
-| __riscv_misaligned_fast | 1  | Scalar isaligned accesses are fast. |
+| __riscv_misaligned_fast | 1  | Scalar misaligned accesses are fast. |
 | __riscv_misaligned_slow | 1  | Scalar misaligned accesses are supported, but may be substantially slower than aligned accesses. |
 | __riscv_misaligned_avoid | 1  | Scalar misaligned accesses are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
 

--- a/riscv-c-api.md
+++ b/riscv-c-api.md
@@ -27,9 +27,9 @@ https://creativecommons.org/licenses/by/4.0/.
 | __riscv_v_min_vlen    | <N> (see [__riscv_v_min_vlen](#__riscv_v_min_vlen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen     | <N> (see [__riscv_v_elen](#__riscv_v_elen)) | The `V` extension or one of the `Zve*` extensions is available. |
 | __riscv_v_elen_fp  | <N> (see [__riscv_v_elen_fp](#__riscv_v_elen_fp)) | The `V` extension or one of the `Zve*` extensions is available. |
-| __riscv_misaligned_fast | 1  | Misaligned accesses are fast. |
-| __riscv_misaligned_slow | 1  | Misaligned accesses are supported, but may be substantially slower than aligned accesses. |
-| __riscv_misaligned_avoid | 1  | Misaligned accesses are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
+| __riscv_misaligned_fast | 1  | Scalar isaligned accesses are fast. |
+| __riscv_misaligned_slow | 1  | Scalar misaligned accesses are supported, but may be substantially slower than aligned accesses. |
+| __riscv_misaligned_avoid | 1  | Scalar misaligned accesses are not supported and could trap. (see [ __riscv_misaligned_{fast,slow,avoid}](#__riscv_misaligned_{fast,slow,avoid}) |
 
 ### __riscv_v_min_vlen
 
@@ -84,7 +84,7 @@ If none of the rules apply, `__riscv_v_elen_fp` is undefined.
 ### __riscv_misaligned_{fast,slow,avoid}
 
 These can be used in common library code to compile time segregate code which relies
-on misaligned access being fast or not.
+on scalar misaligned access being fast or not.
 A typical compiler could (but not necessarily) map fast variant to -mno-strict-align
 and avoid to -mstrict-align, if specified.
 Perhaps obvious, but these are mutually exclusive, so only one is defined at a time


### PR DESCRIPTION
This seems to the direction we're moving -mstrict-align/-mno-strict-align towards.