### PR TITLE
Add __riscv_cmodel_large define for large code model

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -149,6 +149,7 @@ For example:
 |*Name*                     |*Value* |*When defined*
 |`+__riscv_cmodel_medlow+` |1        |Defined if using `medlow` code model.
 |`+__riscv_cmodel_medany+` |1        |Defined if using `medany` code model.
+|`+__riscv_cmodel_large+`  |1        |Defined if using `large` code model.
 |===
 
 === Deprecated Preprocessor Definitions


### PR DESCRIPTION
With https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/388 landed it makes sense to have a define for the large code model for consistency with medany and medlow.