### PR TITLE
Add macro to test endianness

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -13,6 +13,12 @@ a|
 * 128 for rv128
 |Always defined.
 
+|`+__riscv_endianness+`
+a|
+* 'B' for big-endian
+* 'L' for little-endian
+|Always defined.
+
 |`+__riscv_flen+`
 a|
 * 32 if the F extension is available *or*


### PR DESCRIPTION
The RISC-V ELF Specification allow both big-endian and little-endian but there is no macro on RISC-V C API to check the host endianness.