### PR TITLE
[FMV] use long long type for marchid and mimpid

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -837,8 +837,8 @@ struct {
 
 struct {
   unsigned mvendorid;
-  unsigned marchid;
-  unsigned mimpid;
+  unsigned long long marchid;
+  unsigned long long mimpid;
 } __riscv_cpu_model;
 ```
 


### PR DESCRIPTION
PR #74 introduced __riscv_cpu_model data struct for Function Multi-Versioning.

However, unlike fixed 32-bit mvendorid CSR, marchid and mimpid are MXLEN-sized CSR. The Linux kernel will also return these in u64 type, which takes a `long` typed value from MXLEN-sized SBI ecall. I think it's better to turn these fields to `unsigned long long` instead of  `unsigned`. It's still possible to make this change since these codes were only implemented in LLVM, but they now have no users.