### PR TITLE
Inline Asm Constraints and Modifiers - RVC, Raw Encodings, Pairs

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -752,7 +752,7 @@ to aid portability of floating-point code.
 |J                  |Zero integer immediate operand               |
 |s                  |symbol or label reference with a constant offset |
 |cr                 |RVC general purpose register (`x8`-`x15`)  |
-|cf                 |RVC floating-point register (`f8`-`f15`)   |
+|cf                 |RVC floating-point register (`f8`-`f15` or `x8-x15` with `Zfinx`) |
 |Pr                 |Even-odd general purpose register pair     |
 |vr                 |Vector register                    |
 |vd                 |Vector register, excluding v0      |

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -733,6 +733,11 @@ Sign extension of 32-bit values on RV64 is not reflected in the interface.
 This section lists operand constraints that can be used with inline assembly
 statements, including both RISC-V specific and common operand constraints.
 
+"Floating-point register" in both the `f` and `cf` rows means "a register
+suitable for passing a floating-point value", so when using the `Zfinx`,
+`Zdinx`, or `Zhinxmin` extensions this will allocate an X register. This is done
+to aid portability of floating-point code.
+
 .Constraints on Operands of Inline Assembly Statements
 [%autowidth]
 |===
@@ -747,12 +752,18 @@ statements, including both RISC-V specific and common operand constraints.
 |J                  |Zero integer immediate operand               |
 |s                  |symbol or label reference with a constant offset |
 |cr                 |RVC general purpose register (`x8`-`x15`)  |
-|cf                 |RVC floating point register (`f8`-`f15`)   |
+|cf                 |RVC floating-point register (`f8`-`f15`)   |
 |Pr                 |Even-odd general purpose register pair     |
 |vr                 |Vector register                    |
 |vd                 |Vector register, excluding v0      |
 |vm                 |Vector register, only v0           |
 |===
+
+The `Pr` constraint should print as the even register in the pair, as this
+matches how the `amocas.q` instruction (on RV64) or the `amocas.d` and `Zdinx`
+instructions (on RV32) expect to parse their pair register operands. However,
+both registers in the pair should be considered to be live or clobbered
+together.
 
 NOTE: Immediate value must be a compile-time constant.
 

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -746,12 +746,17 @@ statements, including both RISC-V specific and common operand constraints.
 |K                  |5-bit unsigned immediate integer operand     |
 |J                  |Zero integer immediate operand               |
 |s                  |symbol or label reference with a constant offset |
+|cr                 |RVC general purpose register (`x8`-`x15`)  |
+|cf                 |RVC floating point register (`f8`-`f15`)   |
+|Pr                 |Even-odd general purpose register pair     |
 |vr                 |Vector register                    |
 |vd                 |Vector register, excluding v0      |
 |vm                 |Vector register, only v0           |
 |===
 
 NOTE: Immediate value must be a compile-time constant.
+
+NOTE: The `c*` and `P*` constraints are designed to be extensible to more kinds of registers in the future.
 
 === The Difference Between `m` and `A` Constraints
 
@@ -809,6 +814,7 @@ statements, including both RISC-V specific and common operand modifiers.
 |*Modifiers*       |*Description*                                                                  |*Note*
 |z            |Print `zero` (`x0`) register for immediate 0, typically used with constraints `J` |
 |i            |Print `i` if corresponding operand is immediate.                                  |
+|N            |Print register encoding as integer (0-31). |
 |===
 
 [id=function-multi-version]

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -736,7 +736,7 @@ statements, including both RISC-V specific and common operand constraints.
 .Constraints on Operands of Inline Assembly Statements
 [%autowidth]
 |===
-|*Constraint*       |                                             |*Note*
+|*Constraint*       |*Description*                                |*Note*
 |m                  |An address that is held in a general-purpose register with offset. |
 |A                  |An address that is held in a general-purpose register. |
 |r                  |General purpose register                     |

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -732,6 +732,7 @@ Sign extension of 32-bit values on RV64 is not reflected in the interface.
 
 This section lists operand constraints that can be used with inline assembly
 statements, including both RISC-V specific and common operand constraints.
+Operand constraints are case-sensitive.
 
 "Floating-point register" in both the `f` and `cf` rows means "a register
 suitable for passing a floating-point value", so when using the `Zfinx`,
@@ -753,13 +754,13 @@ to aid portability of floating-point code.
 |s                  |symbol or label reference with a constant offset |
 |cr                 |RVC general purpose register (`x8`-`x15`)  |
 |cf                 |RVC floating-point register (`f8`-`f15` or `x8-x15` with `Zfinx`) |
-|Pr                 |Even-odd general purpose register pair     |
+|R                  |Even-odd general purpose register pair     |
 |vr                 |Vector register                    |
 |vd                 |Vector register, excluding v0      |
 |vm                 |Vector register, only v0           |
 |===
 
-The `Pr` constraint should print as the even register in the pair, as this
+The `R` constraint should print as the even register in the pair, as this
 matches how the `amocas.q` instruction (on RV64) or the `amocas.d` and `Zdinx`
 instructions (on RV32) expect to parse their pair register operands. However,
 both registers in the pair should be considered to be live or clobbered
@@ -767,7 +768,8 @@ together.
 
 NOTE: Immediate value must be a compile-time constant.
 
-NOTE: The `c*` and `P*` constraints are designed to be extensible to more kinds of registers in the future.
+NOTE: The `c*` constraints are designed to be extensible to more kinds of
+RVC-compatible register constraints in the future.
 
 === The Difference Between `m` and `A` Constraints
 


### PR DESCRIPTION
We have customers with usecases that want more kinds of register
constraints and modifiers. This change proposes support for these
constraints and modifiers, and their names.

Broadly, these are intended to make it easier for users who want to
manually assemble instructions inside inline assembly blocks, either
using the existing instruction formats, or using the raw form of the
`.insn` directive. This makes it easier for hardware designers to
experiment on new ISA extensions, and makes it easier to support
the use of proprietary extensions with unmodified open-source
toolchains.

There are three groups of additions here:

- Constraints for RVC-compatible registers. These use the `c` prefix on
  an existing register constraint, so `cr` gives a GPR between x8-x15,
  and `cf` does the same for an FPR between f8-f15.

  I'm not aware of compressed vector instructions, but we could add
  `cvr`, `cvd` and `cvm` in the future if the core architecture ends up
  having the concept of a vector register with an RVC encoding.

- A modifier, `N`, to print the raw encoding of a register. This is used
  when using `.insn <length>, <encoding>`, where the user wants to pass
  a value to the instruction in a known register, but where the
  instruction doesn't follow the existing instruction formats, so the
  assembly parser is not expecting a register name, just a raw integer.

- Constraints for even-odd pairs of general-purpose registers. These use
  the `R` constraint.

  While the concept of even-odd register pairs is reasonably "new",
  there are places in the architecture where these already exist - the
  doubleword/quad CAS in Zacas, and they are also present in the Zilsd
  specification.

---

There's also a commit which fixes a header for the Assembly Constraints table.