### PR TITLE
Introduce new attribute `norelax`

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -444,6 +444,25 @@ Functions declared with this attribute will use to the standard vector calling
 convention variant as defined in the RISC-V psABI, even if the function has
 vector arguments or a return value.
 
+=== norelax
+
+Supported Syntaxes:
+.Supported Syntaxes:
+[%autowidth]
+|===
+|*Style*  |*Syntax*
+|GNU    |`+__attribute__((norelax))+`
+|C++11  |`+[[riscv::norelax]]+`
+|C23    |`+[[riscv::norelax]]+`
+|===
+
+Functions declared with this attribute will not be relaxed by the linker.
+
+NOTE: This can be implemented with `.option push; .option norelax; <function-body>; .option pop`.
+NOTE: The use case for this attribute is to apply it to functions that may be invoked
+at a very early stage of the process, when the GP may not be initialized properly at that
+moment.
+
 == Intrinsic Functions
 
 Intrinsic functions (or intrinsics or built-ins) are expanded into instruction sequences by compilers.

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -462,7 +462,8 @@ NOTE: This can be implemented with `.option push; .option norelax; <function-bod
 NOTE: The use case for this attribute is to apply it to functions that may be invoked
 at a very early stage of the process, when the GP may not be initialized properly at that
 moment.
-NOTE: The compiler may automatically apply this attribute to ifunc resolver functions.
+NOTE: Functions used as ifunc resolvers should use this attribute. The compiler
+may apply this to automatically generated ifunc resolvers.
 
 == Intrinsic Functions
 

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -462,6 +462,7 @@ NOTE: This can be implemented with `.option push; .option norelax; <function-bod
 NOTE: The use case for this attribute is to apply it to functions that may be invoked
 at a very early stage of the process, when the GP may not be initialized properly at that
 moment.
+NOTE: The compiler may automatically apply this attribute to ifunc resolver functions.
 
 == Intrinsic Functions
 


### PR DESCRIPTION
This commit introduces the `norelax` attribute for RISC-V, designed to prevent linker relaxation for functions that may be called at very early stages of program execution. The attribute supports multiple syntax styles:

- GNU: `__attribute__((norelax))`
- C++11: `[[riscv::norelax]]`
- C23: `[[riscv::norelax]]`

Functions declared with this attribute will not be relaxed by the linker, ensuring stability in cases where the global pointer (GP) may not yet be initialized.

This is particularly relevant for cases like `ifunc` resolvers, which are invoked before GP initialization.

Implementation Note:
The attribute functionality can be achieved with `.option push; .option norelax; <function-body>; .option pop`.

This attribute is particularly useful in scenarios where functions are invoked before the GP is properly set up, preventing potential early-stage execution errors.