### PR TITLE
Add RVC GPR Pair Constraint - `cR`

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -755,6 +755,7 @@ to aid portability of floating-point code.
 |cr                 |RVC general purpose register (`x8`-`x15`)  |
 |cf                 |RVC floating-point register (`f8`-`f15` or `x8-x15` with `Zfinx`) |
 |R                  |Even-odd general purpose register pair     |
+|cR                 |RVC even-odd general purpose register pair (`x8`-`x14`) |
 |vr                 |Vector register                    |
 |vd                 |Vector register, excluding v0      |
 |vm                 |Vector register, only v0           |


### PR DESCRIPTION
This follows the notion of using `c` as a prefix to mean "RVC-compatible", and `R` to mean "even-odd GPR Pair".

The Zclsd specification adds registers with this constraint, in particular the `c.ld` and `c.sd` instructions need it.