### PR TITLE
Add Zilsd, Zclsd, Zcmp to Extension Bitmask

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -940,6 +940,9 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zcf | 1 | 5
 | zcmop | 1 | 6
 | zawrs | 1 | 7
+| zilsd | 1 | 8
+| zclsd | 1 | 9
+| zcmp | 1 | 10
 |====
 
 === Version Selection


### PR DESCRIPTION
Zilsd, Zclsd and Zcmp are ratified standard extensions which lack bit assignments. I've just appended them to the end.

Note that Zcmop, which is already listed next to the non-Zcmp Zce extensions, is its own extension, not a typo for Zcmp.

For context, I'm considering exposing this bit mask through a custom M-mode CSR  on an embedded-class core to list hardware capabilities with finer granularity than `misa`, but less complexity than the configuration struct or device tree. I implement the three extensions added by this PR.