### PR TITLE
Add bitmask for Q

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -894,6 +894,7 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | f | 0 | 5
 | i | 0 | 8
 | m | 0 | 12
+| q | 0 | 16
 | v | 0 | 21
 | zacas | 0 | 26
 | zba | 0 | 27


### PR DESCRIPTION
Q is the standard extension for Quad-precision floating point.
https://github.com/llvm/llvm-project/pull/139369 is going to add assembly support for the Q extension.

https://github.com/riscv/riscv-isa-manual/blob/main/src/machine.adoc