### PR TITLE
Add E and Q ext to Extension Bitmask

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -891,9 +891,11 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | a | 0 | 0
 | c | 0 | 2
 | d | 0 | 3
+| e | 0 | 4
 | f | 0 | 5
 | i | 0 | 8
 | m | 0 | 12
+| q | 0 | 16
 | v | 0 | 21
 | zacas | 0 | 26
 | zba | 0 | 27


### PR DESCRIPTION
Embedded and Quad-precision floating-point extensions' bitmask have been defined in misa bit position. The implement of Q ext in GCC needs the bitmask. 

In addition, the bitmask of zqinx、zdinx、zfinx、zhinx have not been defined. Should they be added at the end of bitmask?