### PR TITLE
Add Defined misa Bits

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -889,9 +889,12 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 |====
 | extension | groupid | bit position
 | a | 0 | 0
+| b | 0 | 1
 | c | 0 | 2
 | d | 0 | 3
+| e | 0 | 4
 | f | 0 | 5
+| h | 0 | 7
 | i | 0 | 8
 | m | 0 | 12
 | v | 0 | 21


### PR DESCRIPTION
This adds the bits that are defined already in `misa.Extensions`, in the privileged spec, following the note above the table, and existing ratified extensions.

While we would not expect all of these to be present in an OS-level hwcap interface (for example the H bit), I think it is fine to allocate these for the single-letter part of the bitmask, so these bits are not otherwise used.

---

This follows #107 in finishing defining the single-letter extensions that are defined so far.