### PR TITLE
Add bitmap definition for Zifencei and Zmmul

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -949,6 +949,8 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zilsd | 1 | 8
 | zclsd | 1 | 9
 | zcmp | 1 | 10
+| zifencei | 1 | 11
+| zmmul | 1 | 12
 |====
 
 === Version Selection


### PR DESCRIPTION
Following on from #109, which added the single-letter extensions. Zifencei is a standard, ratified extension so seems worth a bitmap definition, even though I understand e.g. Linux has reasons for not exposing it.

The motivation here is just to have an assigned bit for all standard extensions [I implement](https://github.com/Wren6991/Hazard3/tree/develop), since I now expose this bitmap directly in hardware. Zifencei is the only one missing, so I don't plan to continue to trickle these in.