### PR TITLE
Add Zibi to extension bitmask definitions

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -1000,6 +1000,7 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zcmp | 1 | 10
 | zifencei | 1 | 11
 | zmmul | 1 | 12
+| zibi | 1 | 13
 |====
 
 === Version Selection


### PR DESCRIPTION
This extension is currently under review and not yet ratified. However I would like to reserve a bit for it, and make sure that no other extensions are assigned that bit in the meantime.

See here for information about the review period for Zibi: https://lists.riscv.org/g/tech-unprivileged/topic/risc_v_internal_review/117358404

I expose this bitmap in a [hardware CSR](https://wren.wtf/hazard3/doc/#reg-h3.misa), so having a bit assigned would be useful for my experimental Zibi implementation.

