### PR TITLE
Propose extension bitmask assignments for newer standard RISC-V extensions

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -1004,6 +1004,19 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zcmp | 1 | 10
 | zifencei | 1 | 11
 | zmmul | 1 | 12
+| supm | 1 | 14
+| zicntr | 1 | 15
+| zihpm | 1 | 16
+| zfbfmin | 1 | 17
+| zvfbfmin | 1 | 18
+| zvfbfwma | 1 | 19
+| zicbom | 1 | 20
+| zaamo | 1 | 21
+| zalrsc | 1 | 22
+| zabha | 1 | 23
+| zalasr | 1 | 24
+| zicbop | 1 | 25
+| zicflip | 1 | 26
 |====
 
 === Version Selection

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -1016,7 +1016,7 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zabha | 1 | 23
 | zalasr | 1 | 24
 | zicbop | 1 | 25
-| zicflip | 1 | 26
+| zicfilp | 1 | 26
 |====
 
 === Version Selection

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -1073,7 +1073,7 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zabha | 1 | 23
 | zalasr | 1 | 24
 | zicbop | 1 | 25
-| zicflip | 1 | 26
+| zicfilp | 1 | 26
 |====
 
 === Version Selection

--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -1061,6 +1061,19 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zifencei | 1 | 11
 | zmmul | 1 | 12
 | zibi | 1 | 13
+| supm | 1 | 14
+| zicntr | 1 | 15
+| zihpm | 1 | 16
+| zfbfmin | 1 | 17
+| zvfbfmin | 1 | 18
+| zvfbfwma | 1 | 19
+| zicbom | 1 | 20
+| zaamo | 1 | 21
+| zalrsc | 1 | 22
+| zabha | 1 | 23
+| zalasr | 1 | 24
+| zicbop | 1 | 25
+| zicflip | 1 | 26
 |====
 
 === Version Selection


### PR DESCRIPTION
Proposing bitmask assignments for some standard RISC-V extensions that currently do not have entries in the table.

I am working on LLVM support for newer RISC-V extensions already exposed by Linux `hwprobe`. These extensions currently do not have assignments in the bitmask assignment table, so I am proposing assignments for them here.

An open [PR](https://github.com/riscv-non-isa/riscv-c-api-doc/pull/171) already reserves (1,13), so this proposal starts from the next available slot and assigns entries sequentially:

- supm -> (1, 14)
- zicntr -> (1, 15)
- zihpm -> (1, 16)
- zfbfmin -> (1, 17)
- zvfbfmin -> (1, 18)
- zvfbfwma -> (1, 19)
- zicbom -> (1, 20)
- zaamo -> (1, 21)
- zalrsc -> (1, 22)
- zabha -> (1, 23)
- zalasr -> (1, 24)
- zicbop -> (1, 25)
- zicfilp -> (1, 26)