### PR TITLE
Define extension bit for zicfiss

### DIFF
--- a/src/c-api.adoc
+++ b/src/c-api.adoc
@@ -1074,6 +1074,7 @@ Each queryable extension must have an associated `groupid` and `bitmask` that in
 | zalasr | 1 | 24
 | zicbop | 1 | 25
 | zicfilp | 1 | 26
+| zicfiss | 1 | 27
 |====
 
 === Version Selection


### PR DESCRIPTION
Add zicfiss to the standard extension bitmask table.

Use group 1 bit 27 so the assignment does not conflict with the pending group 1 bits 14 through 26 proposed by riscv-c-api-doc PR #185.